### PR TITLE
Display 'no data' on semesters without data

### DIFF
--- a/src/actions/semesterActions.js
+++ b/src/actions/semesterActions.js
@@ -8,20 +8,29 @@ function receiveSemesterData (semester) {
   }
 }
 
+export function invalidateSemesterData (semester) {
+  return {
+    ...semester,
+    valid: false,
+  }
+}
+
 export function fetchSemesterData (semesterCallback, date) {
   return function semesterDataThunk (dispatch, getState) {
     const {semester} = getState()
-    if (semester && dateInSemester(semester, date)) {
+    if (semester && semester.valid && dateInSemester(semester, date)) {
       return
     }
 
     semesterCallback(data => {
       if (!data) {
+        dispatch(receiveSemesterData(invalidateSemesterData(semester)))
         return
       }
 
       const currentSemester = findSemester(data, date)
       if (!currentSemester) {
+        dispatch(receiveSemesterData(invalidateSemesterData(semester)))
         return
       }
 

--- a/src/callbacks/sirius.js
+++ b/src/callbacks/sirius.js
@@ -322,7 +322,7 @@ var semesterDataCallback = function (callback) {
             examsStartsAt: semester.exams_start_at,
             examsEndsAt: semester.exams_end_at,
             hourDuration: semester.hour_duration,
-            breakDuration: 15,
+            breakDuration: 15,  // FIXME: replace this and that two below with semester.hourStarts
             dayStartsAtHour: 7.5,
             dayEndsAtHour: 21.25
           }

--- a/src/callbacks/sirius.js
+++ b/src/callbacks/sirius.js
@@ -365,6 +365,7 @@ function viewChangeCallback (view, param) {
 // If the user is not logged in, redirect him to the landing page
 if (!isUserLoggedIn()) {
   window.location.href = 'landing.html'
+
 } else {
   // Prepare the options object with default values
   var options = {

--- a/src/components/Controls.jsx
+++ b/src/components/Controls.jsx
@@ -11,13 +11,14 @@ import WeekNav from './WeekNav'
 import FunctionsBar from './FunctionsBar'
 import WeekSwitcher from './WeekSwitcher'
 import { shiftDate, isWeekend } from '../date'
+import { semester as semesterType } from '../constants/propTypes'
 
 const propTypes = {
   onDateChange: PropTypes.func.isRequired,
   onSettingsPanelChange: PropTypes.func.isRequired,
   viewDate: React.PropTypes.instanceOf(Date),
   days7: PropTypes.bool,
-  semester: PropTypes.string,
+  semester: semesterType,
 }
 
 class Controls extends React.Component {

--- a/src/components/WeekSwitcher.jsx
+++ b/src/components/WeekSwitcher.jsx
@@ -34,7 +34,7 @@ class WeekSwitcher extends Toggleable {
   }
 
   renderSemesterSelector () {
-    const name = semesterName(this.props.semester, CP) || 'no semester'
+    const name = semesterName(CP.translate.bind(CP), this.props.semester) || 'no semester'
     const viewMoment = this.viewDateMoment()
 
     return (

--- a/src/components/WeekSwitcher.jsx
+++ b/src/components/WeekSwitcher.jsx
@@ -35,7 +35,8 @@ class WeekSwitcher extends Toggleable {
   }
 
   renderSemesterSelector () {
-    const name = semesterName(CP.translate.bind(CP), this.props.semester) || 'no semester'
+    const name = semesterName(CP.translate.bind(CP), this.props.semester) ||
+                 CP.translate('weekNav.unknown_semester')
     const viewMoment = this.viewDateMoment()
 
     return (

--- a/src/components/WeekSwitcher.jsx
+++ b/src/components/WeekSwitcher.jsx
@@ -10,11 +10,12 @@ import CP from 'counterpart'
 
 import Toggleable from './Toggleable'
 import { semesterName } from '../semester'
+import { semester as semesterType } from '../constants/propTypes'
 
 const propTypes = {
   viewDate: PropTypes.instanceOf(Date),
   onDateChange: PropTypes.func,
-  semester: PropTypes.string,
+  semester: semesterType,
 }
 
 class WeekSwitcher extends Toggleable {

--- a/src/components/WeekSwitcher.jsx
+++ b/src/components/WeekSwitcher.jsx
@@ -6,8 +6,10 @@
 
 import React, { PropTypes } from 'react'
 import moment from 'moment'
+import CP from 'counterpart'
 
 import Toggleable from './Toggleable'
+import { semesterName } from '../semester'
 
 const propTypes = {
   viewDate: PropTypes.instanceOf(Date),
@@ -32,9 +34,7 @@ class WeekSwitcher extends Toggleable {
   }
 
   renderSemesterSelector () {
-
-    // Set a semester name
-    const semesterName = this.props.semester
+    const name = semesterName(this.props.semester, CP) || 'no semester'
     const viewMoment = this.viewDateMoment()
 
     return (
@@ -49,7 +49,7 @@ class WeekSwitcher extends Toggleable {
           </button>
         </div>
         <div className="column small-6 active-item">
-          {semesterName}
+          {name}
         </div>
         <div className="column small-3 gr-go">
           <button

--- a/src/constants/propTypes.js
+++ b/src/constants/propTypes.js
@@ -47,6 +47,20 @@ export const grid = PropTypes.shape({
   facultyGrid: PropTypes.bool,
 })
 
+export const semester = PropTypes.shape({
+  id: PropTypes.string,
+  semester: PropTypes.string,
+  faculty: PropTypes.number,
+  startsAt: PropTypes.string,  // FIXME: should be converted to datetime
+  endsAt: PropTypes.string,  // FIXME: should be converted to datetime
+  examsStartsAt: PropTypes.string,  // FIXME: should be converted to datetime
+  examsEndsAt: PropTypes.string,  // FIXME: should be converted to datetime
+  hourDuration: PropTypes.number,
+  breakDuration: PropTypes.number,
+  dayStartsAtHour: PropTypes.number,  // FIXME: this should be probably replaced with hourStarts array
+  dayEndsAtHour: PropTypes.number,  // FIXME: this should be probably replaced with hourStarts array
+})
+
 export const moment = (props, propName, componentName) => {
   const prop = props[propName]
   if (!Moment.isMoment(prop)) {

--- a/src/containers/FittableContainer/FittableContainer.jsx
+++ b/src/containers/FittableContainer/FittableContainer.jsx
@@ -161,7 +161,7 @@ const FittableContainer = React.createClass({
       <div className="fittable-container" ref="rootEl">
         <Header
           calendar={this.props.calendar}
-          semesterName={semesterName(this.props.semester, CP)}
+          semesterName={semesterName(CP.translate.bind(CP), this.props.semester)}
           userName={this.props.user.name || this.props.user.id}
         />
         {/* FIXME: we don't have the view name data inside fittable :( */}

--- a/src/containers/FittableContainer/FittableContainer.jsx
+++ b/src/containers/FittableContainer/FittableContainer.jsx
@@ -105,6 +105,11 @@ const FittableContainer = React.createClass({
   // FIXME: too much logic. should be somewhere else
   getSemesterName () {
     const {semester} = this.props
+
+    if (!semester.valid) {
+      return 'no data'
+    }
+
     if (!semester || !semester.season || !semester.years) {
       return ''
     }

--- a/src/containers/FittableContainer/FittableContainer.jsx
+++ b/src/containers/FittableContainer/FittableContainer.jsx
@@ -20,6 +20,7 @@ import { fetchUserData } from '../../actions/userActions'
 import { changeCalendar } from '../../actions/linkActions'
 
 import { isoDate, strToDate } from '../../date'
+import { semesterName } from '../../semester'
 
 import FunctionsSidebar from '../../components/FunctionsSidebar'
 import Spinner from '../../components/Spinner'
@@ -102,25 +103,6 @@ const FittableContainer = React.createClass({
     }
   },
 
-  // FIXME: too much logic. should be somewhere else
-  getSemesterName () {
-    const {semester} = this.props
-
-    if (!semester.valid) {
-      return 'no data'
-    }
-
-    if (!semester || !semester.season || !semester.years) {
-      return ''
-    }
-
-    const season = semester.season
-    const [beginYear, endYear] = semester.years
-    const translateKey = `${season}_sem`
-
-    return CP.translate(translateKey, {year: `${beginYear}/${endYear}`})
-  },
-
   // FIXME: deprecate callback
   handleChangeViewDate (date) {
     // Close all opened functions
@@ -179,7 +161,7 @@ const FittableContainer = React.createClass({
       <div className="fittable-container" ref="rootEl">
         <Header
           calendar={this.props.calendar}
-          semesterName={this.getSemesterName()}
+          semesterName={semesterName(this.props.semester, CP)}
           userName={this.props.user.name || this.props.user.id}
         />
         {/* FIXME: we don't have the view name data inside fittable :( */}
@@ -187,7 +169,7 @@ const FittableContainer = React.createClass({
           viewDate={this.props.viewDate}
           onWeekChange={this.handleChangeViewDate}
           onDateChange={this.handleChangeViewDate}
-          semester={this.getSemesterName()}
+          semester={this.props.semester}
           onSettingsPanelChange={this.props.onSidebarDisplay}
           days7={fullWeek}
           screenSize={this.props.screenSize}

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -39,7 +39,8 @@
     "prev": "Předchozí týden",
     "next": "Následující týden",
     "selector": "Výběr data",
-    "teachweek": "%(weeknum)s týden"
+    "teachweek": "%(weeknum)s týden",
+    "unknown_semester": "neznámý"
   },
 
   "functions": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -39,7 +39,8 @@
     "prev": "Previous week",
     "next": "Next week",
     "selector": "Date selector",
-    "teachweek": "%(weeknum)s week"
+    "teachweek": "%(weeknum)s week",
+    "unknown_semester": "unknown"
   },
 
   "functions": {

--- a/src/reducers/semesterReducer.js
+++ b/src/reducers/semesterReducer.js
@@ -9,6 +9,7 @@ const initialState = {
     lessonDuration: 0.875,
   },
   periods: [],
+  valid: false,
   /*
   startsOn,
   endsOn,

--- a/src/semester.js
+++ b/src/semester.js
@@ -61,13 +61,10 @@ export function convertRawSemester (semester) {
 }
 
 export function semesterName (translate, semester) {
-  if (!semester.valid || !semester || !semester.season || !semester.years) {
+  if (!semester || !semester.valid || !semester.season || !semester.years) {
     return null
   }
+  const translateKey = `${semester.season}_sem`
 
-  const season = semester.season
-  const [beginYear, endYear] = semester.years
-  const translateKey = `${season}_sem`
-
-  return translate(translateKey, {year: `${beginYear}/${endYear}`})
+  return translate(translateKey, { year: semester.years.join('/') })
 }

--- a/src/semester.js
+++ b/src/semester.js
@@ -56,5 +56,6 @@ export function convertRawSemester (semester) {
         endsOn: semester.examsEndsAt,
       },
     ],
+    valid: true,
   }
 }

--- a/src/semester.js
+++ b/src/semester.js
@@ -60,7 +60,7 @@ export function convertRawSemester (semester) {
   }
 }
 
-export function semesterName (semester, counterpart) {
+export function semesterName (translate, semester) {
   if (!semester.valid || !semester || !semester.season || !semester.years) {
     return null
   }
@@ -69,5 +69,5 @@ export function semesterName (semester, counterpart) {
   const [beginYear, endYear] = semester.years
   const translateKey = `${season}_sem`
 
-  return counterpart.translate(translateKey, {year: `${beginYear}/${endYear}`})
+  return translate(translateKey, {year: `${beginYear}/${endYear}`})
 }

--- a/src/semester.js
+++ b/src/semester.js
@@ -59,3 +59,15 @@ export function convertRawSemester (semester) {
     valid: true,
   }
 }
+
+export function semesterName (semester, counterpart) {
+  if (!semester.valid || !semester || !semester.season || !semester.years) {
+    return null
+  }
+
+  const season = semester.season
+  const [beginYear, endYear] = semester.years
+  const translateKey = `${season}_sem`
+
+  return counterpart.translate(translateKey, {year: `${beginYear}/${endYear}`})
+}

--- a/src/semester.js
+++ b/src/semester.js
@@ -65,6 +65,7 @@ export function semesterName (translate, semester) {
     return null
   }
   const translateKey = `${semester.season}_sem`
+  const academicYear = `${semester.years[0]}/${semester.years[1] % 100}`
 
-  return translate(translateKey, { year: semester.years.join('/') })
+  return translate(translateKey, { year: academicYear })
 }

--- a/test/actions/semesterActions.test.js
+++ b/test/actions/semesterActions.test.js
@@ -78,6 +78,7 @@ test('fetchSemesterData() dispatch with semester loaded', t => {
     semester: {
       startsOn: '2015-02-18',
       endsOn: '2015-09-21',
+      valid: true,
     },
   }
 
@@ -89,5 +90,25 @@ test('fetchSemesterData() dispatch with semester loaded', t => {
   thunk(dispatch, () => state)
   t.equal(callback.callCount, 0, 'does not execute callback if the date is already within current semester')
   t.equal(dispatch.callCount, 0, 'does not dispatches action if the date is already within current semester')
+  t.end()
+})
+
+test('invalidateSemesterData()', t => {
+  const semester = {
+    season: 'winter',
+    valid: true,
+    years: [2015, 2016],
+  }
+
+  const expected = {
+    season: 'winter',
+    valid: false,
+    years: [2015, 2016],
+  }
+
+  const invalidated = actions.invalidateSemesterData(semester)
+
+  t.deepEqual(invalidated, expected, 'invalidate semester')
+  t.deepEqual(actions.invalidateSemesterData(invalidated), expected, 'invalidating invalidated semester does nothing')
   t.end()
 })

--- a/test/reducers/semesterReducer.test.js
+++ b/test/reducers/semesterReducer.test.js
@@ -11,6 +11,7 @@ const INITIAL_STATE = {
     lessonDuration: 0.875,
   },
   periods: [],
+  valid: false,
 }
 
 test('semester reducer initial state', t => {

--- a/test/semester.test.js
+++ b/test/semester.test.js
@@ -101,11 +101,9 @@ test('semesterName()', t => {
   const dispatch = spy()
 
   // faux counterpart
-  const fcounterpart = {
-    translate: (key, options) => {
-      dispatch(key, options)
-      return 'translated-string'
-    },
+  const translate = (key, options) => {
+    dispatch(key, options)
+    return 'translated-string'
   }
 
   const semester = {
@@ -113,14 +111,14 @@ test('semesterName()', t => {
     valid: true,
     years: [2015, 2016],
   }
-  s.semesterName(semester, fcounterpart)
+  s.semesterName(translate, semester)
 
   const semester2 = {
     season: 'summer',
     valid: true,
     years: [2016, 2017],
   }
-  s.semesterName(semester2, fcounterpart)
+  s.semesterName(translate, semester2)
 
   const invsemester = {
     season: 'summer',
@@ -133,9 +131,9 @@ test('semesterName()', t => {
   t.deepEqual(dispatch.firstCall.args, ['winter_sem', {year: '2015/2016'}], 'correctly recognize winter sem. 15/16')
   t.deepEqual(dispatch.lastCall.args, ['summer_sem', {year: '2016/2017'}], 'correctly recognize summer sem. 16/17')
 
-  t.equal(s.semesterName(semester, fcounterpart), 'translated-string', 'returns translated string from counterpart')
-  t.equal(s.semesterName(invsemester, fcounterpart), null, 'returns null on invalid semesters')
-  t.equal(s.semesterName(emptysemester, fcounterpart), null, 'returns null on semesters with missing data')
+  t.equal(s.semesterName(translate, semester), 'translated-string', 'returns translated string from counterpart')
+  t.equal(s.semesterName(translate, invsemester), null, 'returns null on invalid semesters')
+  t.equal(s.semesterName(translate, emptysemester), null, 'returns null on semesters with missing data')
 
   t.end()
 })

--- a/test/semester.test.js
+++ b/test/semester.test.js
@@ -75,6 +75,7 @@ test('convertRawSemester()', t => {
         endsOn: '2015-06-27',
       },
     ],
+    valid: true,
   }
 
   const actual = s.convertRawSemester(original)

--- a/test/semester.test.js
+++ b/test/semester.test.js
@@ -128,8 +128,8 @@ test('semesterName()', t => {
 
   const emptysemester = { }
 
-  t.deepEqual(dispatch.firstCall.args, ['winter_sem', {year: '2015/2016'}], 'correctly recognize winter sem. 15/16')
-  t.deepEqual(dispatch.lastCall.args, ['summer_sem', {year: '2016/2017'}], 'correctly recognize summer sem. 16/17')
+  t.deepEqual(dispatch.firstCall.args, ['winter_sem', {year: '2015/16'}], 'correctly recognize winter sem. 15/16')
+  t.deepEqual(dispatch.lastCall.args, ['summer_sem', {year: '2016/17'}], 'correctly recognize summer sem. 16/17')
 
   t.equal(s.semesterName(translate, semester), 'translated-string', 'returns translated string from counterpart')
   t.equal(s.semesterName(translate, invsemester), null, 'returns null on invalid semesters')

--- a/test/semester.test.js
+++ b/test/semester.test.js
@@ -1,4 +1,5 @@
 import test from 'blue-tape'
+import { spy } from 'sinon'
 import * as s from '../src/semester'
 
 test('currentSemester()', t => {
@@ -93,5 +94,48 @@ test('dateInSemester()', t => {
   const dateOut = new Date('2015-10-01')
   t.equal(s.dateInSemester(semester, dateIn), true, 'returns true for date within the semester')
   t.equal(s.dateInSemester(semester, dateOut), false, 'returns false for date outside of the semester')
+  t.end()
+})
+
+test('semesterName()', t => {
+  const dispatch = spy()
+
+  // faux counterpart
+  const fcounterpart = {
+    translate: (key, options) => {
+      dispatch(key, options)
+      return 'translated-string'
+    },
+  }
+
+  const semester = {
+    season: 'winter',
+    valid: true,
+    years: [2015, 2016],
+  }
+  s.semesterName(semester, fcounterpart)
+
+  const semester2 = {
+    season: 'summer',
+    valid: true,
+    years: [2016, 2017],
+  }
+  s.semesterName(semester2, fcounterpart)
+
+  const invsemester = {
+    season: 'summer',
+    valid: false,
+    years: [2016, 2017],
+  }
+
+  const emptysemester = { }
+
+  t.deepEqual(dispatch.firstCall.args, ['winter_sem', {year: '2015/2016'}], 'correctly recognize winter sem. 15/16')
+  t.deepEqual(dispatch.lastCall.args, ['summer_sem', {year: '2016/2017'}], 'correctly recognize summer sem. 16/17')
+
+  t.equal(s.semesterName(semester, fcounterpart), 'translated-string', 'returns translated string from counterpart')
+  t.equal(s.semesterName(invsemester, fcounterpart), null, 'returns null on invalid semesters')
+  t.equal(s.semesterName(emptysemester, fcounterpart), null, 'returns null on semesters with missing data')
+
   t.end()
 })


### PR DESCRIPTION
I've added the new `valid` property of semester object. When it's invalid, 'no data' is being displayed.

Resolves #143 
