### PR TITLE
Display course name in event detail when event name is not set

### DIFF
--- a/src/components/EventDetail.jsx
+++ b/src/components/EventDetail.jsx
@@ -62,9 +62,22 @@ class EventDetail extends React.Component {
     return this.props.linkNames[CP.getLocale()][type][key] || key
   }
 
+  getEventName () {
+    let name = this.props.data.name
+
+    // Lectures, tutorials, and laboratories don't have name.
+    if (name) {
+      name = name[CP.getLocale()] || name.cs
+    }
+    // If event name is not set, use course name instead.
+    if (!name) {
+      name = this.getLinkName('courses', this.props.data.course)
+    }
+    return name
+  }
+
   eventBasicProps () {
     const seqNumber = this.props.data.sequenceNumber || '?'
-    const name = this.props.data.name || this.getLinkName('courses', this.props.data.course)
 
     return (
       <div className="prop-section basic-props">
@@ -73,7 +86,7 @@ class EventDetail extends React.Component {
         </div>
         <div className="name">
           <button onClick={this.handleCourseClick.bind(this, this.props.data.course) }>
-            {name[CP.getLocale()] || name.cs}
+            {this.getEventName()}
           </button>
         </div>
         <div className="location">


### PR DESCRIPTION
I’ve broken it in hotfix 95d339c5458afc1b7a720f44cbbdff974dba32b6, so this a fix that fixes the previous fix… Sorry for that.

@jnv, review plz, ASAP
