### PR TITLE
Generate empty calendar url for people/me

### DIFF
--- a/src/actions/linkActions.js
+++ b/src/actions/linkActions.js
@@ -14,7 +14,12 @@ export function calendarUrl ({id, date, type = null}) {
   const urlType = entityType(type)
   const dateQuery = date ? `?date=${date}` : ''
 
-  return `${urlType}/${id}${dateQuery}`
+  let path = `${urlType}/${id}`
+  if (urlType === 'people' && id === 'me') {
+    path = ''
+  }
+
+  return `${path}${dateQuery}`
 }
 
 export function changeCalendar (calendar) {

--- a/test/actions/linkActions.test.js
+++ b/test/actions/linkActions.test.js
@@ -25,6 +25,19 @@ test('calendarUrl()', t => {
     st.equal(actual, expected, 'generates URL without a date')
   })
 
+  t.test('calendarUrl() for people/me', st => {
+    st.plan(1)
+    const expected = ''
+    const calendar = {
+      type: 'person',
+      id: 'me',
+      date: null,
+    }
+    const actual = actions.calendarUrl(calendar)
+
+    st.equal(actual, expected, 'generates empty URL')
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
Browsing your personal calendar pushes `people/me` to the URL. We want to avoid this behaviour, so `calendarUrl` generates an empty string for that one particular case.
