### PR TITLE
Add missing responsiveness to NowIndicator

### DIFF
--- a/src/components/NowIndicator.jsx
+++ b/src/components/NowIndicator.jsx
@@ -45,8 +45,8 @@ function NowIndicator ({
         <div className="now-indicator horizontal"
              style={{
                height: (dayWidth * 100) + '%',
-               width: (length * 90 + 10) + '%',
-               top: (offset * 100) + '%',
+               width: (length * 100) + '%',
+               top: (offset * 100 + 0.1) + '%', // +0.1% is the grid offset
              }}
         />
       </div>
@@ -57,8 +57,8 @@ function NowIndicator ({
         <div className="now-indicator vertical"
              style={{
                width: (dayWidth * 100) + '%',
-               height: (length * 90 + 10) + '%',
-               left: (offset * 100) + '%',
+               height: (length * 100) + '%',
+               left: (offset * 100 + 0.1) + '%', // +0.1% is the grid offset
              }}
         />
       </div>

--- a/src/stylesheets/components/_table-horizontal.scss
+++ b/src/stylesheets/components/_table-horizontal.scss
@@ -53,6 +53,13 @@
     height: 100%;
   }
 
+  .now-indicator-wrap {
+    top: 0;
+    left: 10%;
+    width: 90%;
+    height: 100%;
+  }
+
   .now-indicator {
     border-bottom: none;
     border-right: $nowindicator-thickness solid $nowindicator-color;

--- a/src/stylesheets/components/_table-responsive.scss
+++ b/src/stylesheets/components/_table-responsive.scss
@@ -34,6 +34,12 @@
     .grid-wrapper {
       top: 0%;
     }
+
+    .now-indicator-wrap {
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 93%;
+    }
   }
 }
-

--- a/src/stylesheets/components/_table.scss
+++ b/src/stylesheets/components/_table.scss
@@ -111,6 +111,14 @@
     height: 100%;
   }
 
+  .now-indicator-wrap {
+    top: 7%;
+    left: 0;
+    width: 100%;
+    height: 93%;
+    position: absolute;
+  }
+
   .now-indicator {
     position: absolute;
     left: 0;


### PR DESCRIPTION
The NowIndicator component ignored the active layout (horizontal, vertical, mobile)

Resolves #185

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cvut/fittable/209)

<!-- Reviewable:end -->
