### PR TITLE
Display type of semester period, teaching week number and parity (fixes #154)

### DIFF
--- a/src/callbacks/sirius.js
+++ b/src/callbacks/sirius.js
@@ -15,7 +15,7 @@ import camelize from 'camelize'
 import { fmoment } from '../date'
 import { renameKeys } from '../utils'
 
-import { SIRIUS_PROXY_PATH } from '../config'
+import { FACULTY_ID, SIRIUS_PROXY_PATH } from '../config'
 
 const emptyObject = (obj) => R.is(Object, obj) && R.pipe(R.keys, R.propEq('length', 0))
 
@@ -275,7 +275,7 @@ function semesterDataCallback (callback) {
     }
   }
 
-  makeRequest(`semesters?limit=${defaultLimit}`, requestHandler)
+  makeRequest(`semesters?faculty=${FACULTY_ID}&limit=${defaultLimit}`, requestHandler)
 }
 
 const convertInterval = R.pipe(

--- a/src/components/Controls.jsx
+++ b/src/components/Controls.jsx
@@ -6,6 +6,7 @@
 import React, { PropTypes } from 'react'
 import { isScreenMediumAndUp } from '../screen'
 
+import SemesterWeek from './SemesterWeek'
 import WeekNav from './WeekNav'
 import FunctionsBar from './FunctionsBar'
 import WeekSwitcher from './WeekSwitcher'
@@ -78,6 +79,10 @@ class Controls extends React.Component {
           viewDate={this.props.viewDate}
           ref="weekSwitcher"
           onDateChange={this.props.onDateChange}
+          semester={this.props.semester}
+        />
+        <SemesterWeek
+          viewDate={this.props.viewDate}
           semester={this.props.semester}
         />
         <FunctionsBar onPanelToggle={this.props.onSettingsPanelChange} />

--- a/src/components/SemesterWeek.jsx
+++ b/src/components/SemesterWeek.jsx
@@ -1,38 +1,34 @@
+import React from 'react'
+import R from 'ramda'
+import { findWeekByDate } from '../semesterWeeks'
+import { translate } from '../locale'
+
+// @sig Week -> String -> String
+const translateWeekName = R.curry((week, type) => {
+  return translate(`semesterWeek.${type}`, {
+    weekNum: week.teachingWeek || '?',
+    parity: translate(week.parity, { fallback: '' }),
+  })
+})
+
+// @sig Week -> String
+const displayName = (week) => {
+  if (!week) { return '' }
+  return R.map(translateWeekName(week), week.types).join(' / ')
+}
+
 /**
- * Week controller located in upper left corner, displaying actual week.
- * On click it toggles the WeekSwitcher component
+ * Displays properties of the specified semester week (period type, teching
+ * week number and parity).
  */
+const SemesterWeek = ({ semester, viewDate }) => {
+  const week = findWeekByDate(semester.weeks || [], viewDate)
 
-import React, { PropTypes } from 'react'
-import moment from 'moment'
-import CP from 'counterpart'
-import { weekRange, workWeekRange } from '../date'
-
-const propTypes = {
-  viewDate: PropTypes.instanceOf(Date),
+  return (
+    <div className="SemesterWeek-text">
+      {displayName(week)}
+    </div>
+  )
 }
-
-class SemesterWeek extends React.Component {
-
-  constructor (props) {
-    super(props)
-    this.state = { open: false }
-  }
-
-  weekNum () {
-    return moment(this.props.viewDate).format('Wo')
-  }
-
-  weekParity () {
-    const parity = moment(this.props.viewDate).isoWeek() % 2 === 0 ? 'even' : 'odd'
-    return CP.translate(parity)
-  }
-
-  render () {
-    return <div className="view-date">{CP.translate('weekNav.teachweek', { weeknum: this.weekNum() })} ({this.weekParity()})</div>
-  }
-}
-
-SemesterWeek.propTypes = propTypes
 
 export default SemesterWeek

--- a/src/components/SemesterWeek.jsx
+++ b/src/components/SemesterWeek.jsx
@@ -12,7 +12,7 @@ const propTypes = {
   viewDate: PropTypes.instanceOf(Date),
 }
 
-class ViewDate extends React.Component {
+class SemesterWeek extends React.Component {
 
   constructor (props) {
     super(props)
@@ -33,6 +33,6 @@ class ViewDate extends React.Component {
   }
 }
 
-ViewDate.propTypes = propTypes
+SemesterWeek.propTypes = propTypes
 
-export default ViewDate
+export default SemesterWeek

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,5 @@
 export const TZ = 'Europe/Prague'
 
 export const SIRIUS_PROXY_PATH = global.SIRIUS_PROXY_PATH || process.env.SIRIUS_PROXY_PATH
+
+export const FACULTY_ID = 18000  // FIT CTU

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,0 +1,17 @@
+import CP from 'counterpart'
+
+/**
+ * Translates, pluralizes and interpolates the given key using the specified
+ * locale, scope, and fallback, as well as interpolation values.
+ *
+ * If the key is null or undefined and the options contains `fallback`, then
+ * the fallback is returned.
+ *
+ * @sig (String, {*}) -> String
+ */
+export function translate (key, options = {}) {
+  if (!key && 'fallback' in options) {
+    return options.fallback
+  }
+  return CP.translate(key, options)
+}

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -39,7 +39,6 @@
     "prev": "Předchozí týden",
     "next": "Následující týden",
     "selector": "Výběr data",
-    "teachweek": "%(weeknum)s týden",
     "unknown_semester": "neznámý"
   },
 

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -1,7 +1,7 @@
 {
   "week": "Týden %(num)s",
-  "even": "Sudý",
-  "odd": "Lichý",
+  "even": "sudý",
+  "odd": "lichý",
   "summer_sem": "%(year)s Letní",
   "winter_sem": "%(year)s Zimní",
 
@@ -40,6 +40,12 @@
     "next": "Následující týden",
     "selector": "Výběr data",
     "unknown_semester": "neznámý"
+  },
+
+  "semesterWeek": {
+    "teaching": "%(weekNum)s. výukový týden (%(parity)s)",
+    "exams": "Zkouškové období",
+    "holiday": "Prázdniny"
   },
 
   "functions": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -39,7 +39,6 @@
     "prev": "Previous week",
     "next": "Next week",
     "selector": "Date selector",
-    "teachweek": "%(weeknum)s week",
     "unknown_semester": "unknown"
   },
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,7 +1,7 @@
 {
   "week": "Week %(num)s",
-  "even": "Even",
-  "odd": "Odd",
+  "even": "even",
+  "odd": "odd",
   "summer_sem": "Summer %(year)s",
   "winter_sem": "Winter %(year)s",
 
@@ -40,6 +40,12 @@
     "next": "Next week",
     "selector": "Date selector",
     "unknown_semester": "unknown"
+  },
+
+  "semesterWeek": {
+    "teaching": "%(weekNum)s. teaching week (%(parity)s)",
+    "exams": "Exams period",
+    "holiday": "Holidays"
   },
 
   "functions": {

--- a/src/semesterWeeks.js
+++ b/src/semesterWeeks.js
@@ -107,7 +107,7 @@ const periodsByWeeks = R.pipe(
  * Transforms the Periods of a single Semester into the Semester Weeks indexed
  * by a Weekstamp (number of weeks since the epoch).
  *
- * @sig [Period] -> {String: SemesterWeek}
+ * @sig [Period] -> SemesterWeeks
  */
 export const semesterPeriodsToWeeks = R.pipe(
   periodsByWeeks,
@@ -123,3 +123,13 @@ export const semesterPeriodsToWeeks = R.pipe(
     })
   ))
 )
+
+/**
+ * Finds Semester Week in the given Semester Weeks object for the
+ * specified date.
+ *
+ * @sig SemesterWeeks -> Moment | Date -> SemesterWeek
+ */
+export const findWeekByDate = R.curry((weeks, date) => {
+  return weeks[weeksSinceEpoch(date)]
+})

--- a/src/stylesheets/_components.scss
+++ b/src/stylesheets/_components.scss
@@ -25,5 +25,6 @@
 @import "components/week-nav-responsive";
 @import "components/week-switcher";
 @import "components/SidebarIcal";
+@import "components/SemesterWeek";
 
 @import "components/signpost-page";

--- a/src/stylesheets/components/_SemesterWeek.scss
+++ b/src/stylesheets/components/_SemesterWeek.scss
@@ -1,0 +1,8 @@
+.SemesterWeek-text {
+  float: left;
+  position: relative;
+  margin-left: 15px;
+  color: $primary-color;
+  line-height: 35px;
+  text-transform: uppercase;
+}

--- a/src/stylesheets/components/_week-nav.scss
+++ b/src/stylesheets/components/_week-nav.scss
@@ -20,14 +20,6 @@
     }
   }
 
-  .view-date {
-    float: left;
-    position: relative;
-    margin-left: 15px;
-    color: $primary-color;
-    line-height: 35px;
-  }
-
   @media #{$large-up} {
     .week-toggle-dow {
       display: none;


### PR DESCRIPTION
I’ve finally finished displaying of semester week, known as issue #154. This PR replaces #180.

It displays nothing when there are no data (undefined period or semester).

![desktop](https://cloud.githubusercontent.com/assets/949228/12433296/a1c8187c-bf00-11e5-85b6-8fd2cc8652d6.gif)

![mobile](https://cloud.githubusercontent.com/assets/949228/12433361/f5a63e06-bf00-11e5-8ab7-3769abe2cf9b.gif)

@mmajko I’m not very happy how it looks on a mobile, do you have some idea how to improve it?
@jnv, review plz.

It’s really sad that we’re shipping this **very important** feature so late…

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cvut/fittable/221)

<!-- Reviewable:end -->
