### PR TITLE
Fix desynced event and nowindicator positions

### DIFF
--- a/src/stylesheets/components/_table.scss
+++ b/src/stylesheets/components/_table.scss
@@ -122,7 +122,7 @@
   .now-indicator {
     position: absolute;
     left: 0;
-    top: 0;
+    top: $nowindicator-thickness;
     height: 107%;
     z-index: 5;
     border-bottom: $nowindicator-thickness solid $nowindicator-color;


### PR DESCRIPTION
I hope it's finally accurate.

Resolves #239 

<img width="870" alt="screen shot 2016-03-08 at 17 00 32" src="https://cloud.githubusercontent.com/assets/3010503/13607586/2a79dab8-e551-11e5-9000-390c1449f866.png">

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cvut/fittable/253)

<!-- Reviewable:end -->
